### PR TITLE
feat : Log Box 수정

### DIFF
--- a/src/components/Log/LogBox.jsx
+++ b/src/components/Log/LogBox.jsx
@@ -137,7 +137,7 @@ function LogBox(prop) {
                         </Box>
                         <Grid container spacing={1}>
                             <Grid item xs={12} sx={{textAlign: 'left', marginLeft: 2}}>
-                                <Typography>해충 피해 발생</Typography>
+                                <Typography>{kind2} 피해 발생 </Typography>
                             </Grid>
                             <Grid item xs={12} sx={{textAlign: 'left', marginLeft: 2}}>
                                 <Typography>{date2}</Typography>
@@ -160,7 +160,7 @@ function LogBox(prop) {
                         </Box>
                         <Grid container spacing={1}>
                             <Grid item xs={12} sx={{textAlign: 'left', marginLeft: 2}}>
-                                <Typography>질병 피해 발생</Typography>
+                                <Typography>{kind2} 피해 발생</Typography>
                             </Grid>
                             <Grid item xs={12} sx={{textAlign: 'left', marginLeft: 2}}>
                                 <Typography>{date2}</Typography>


### PR DESCRIPTION
## 수정내용
- LogBox 벌레 or 질병 종류에 따라 LogBox에 나타나는 텍스트 명 변경

## 기타
- 데이터가 원래 날짜별 벌레 / 질병 2개 그룹으로 나눠져 있던게, 날짜별 벌레 / 질병의 종류별로 나눠져 있고 나머지 image url이나 datetime 등은 잘 묶여 있으면 그대로 box 잘 생성되어야 합니다. (Front는 그렇게 짜여져 있습니다.)
- 테스트 해보시고 말씀해주세요

closed : #69 